### PR TITLE
Override Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,6 @@ Now let's create our module implementation, name it `vending_machine.ex`.
 
 ```elixir
 defmodule VendingMachine do
-  @external_resource "test/support/vending_machine.json"
   use StatesLanguage, data: "test/support/vending_machine.json"
 
   defmodule Data do
@@ -308,6 +307,33 @@ Generated states_language app
 14:41:21.863 [info]  Dispensing one "Snickers"
 
 14:41:21.863 [debug] Elixir.VendingMachine - Terminating in state DispenseNosh :normal
+```
+
+## Persisting process state
+
+It's also possible to override the "Start" state and perhaps pass in a deserialized data object. This would allow you to persist the StatesLanguage process to storage and restart the process where you left off.
+
+For the vending machine example you could pass in your data and a `start` parameter to `start_link` or `start`
+
+```bash
+$ iex -S mix
+iex(1)> data = %Data{test: self(), keypad: %{input: "a123"}, lookup: %{result: %{candy: "Snickers"}}}
+iex(2)> VendingMachine.start_link(data, start: "DispenseNosh")
+iex(3)> flush()
+:finished
+:ok
+```
+
+And your output would look something like this
+
+```
+09:19:04.239 [debug] Elixir.VendingMachine - Init: Data - %VendingMachine.Data{error: "", keypad: %{input: "a123"}, lookup: %{result: %{candy: "Snickers"}}, test: #PID<0.346.0>}
+
+09:19:04.239 [warn]  Unknown enter event from "DispenseNosh" to "DispenseNosh"
+
+09:19:04.239 [info]  Dispensing one "Snickers"
+
+09:19:04.239 [debug] Elixir.VendingMachine - Terminating in state DispenseNosh :normal
 ```
 
 ## Validation

--- a/test/states_language_override_start_test.exs
+++ b/test/states_language_override_start_test.exs
@@ -1,0 +1,18 @@
+defmodule StatesLanguageOverrideStartTest do
+  use ExUnit.Case, async: true
+  require Logger
+  alias VendingMachine.Data
+
+  setup do
+    data = %Data{test: self(), keypad: %{input: "a123"}, lookup: %{result: %{candy: "Snickers"}}}
+    {:ok, client_pid} = VendingMachine.start_link(data, start: "DispenseNosh")
+
+    [client_pid: client_pid]
+  end
+
+  test "client goes through all states" do
+    refute_receive %{event: :input_received}
+    refute_receive :success
+    assert_receive :finished, 1000
+  end
+end


### PR DESCRIPTION
Add ability to override start state on process startup.

This adds a new optional `start` argument to `start` and `start_link` functions.